### PR TITLE
Feature/likes#9

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,20 +8,20 @@ datasource db {
 }
 
 model User {
-  userId        Int           @id @default(autoincrement()) @map("user_id")
-  email         String        @unique @map("email")
-  password      String        @map("password")
-  username      String        @map("username")
-  profileImage  String?       @map("profile_image")
-  introduction  String?       @map("introduction")
-  createdAt     DateTime      @default(now()) @map("created_at")
-  updatedAt     DateTime      @updatedAt @map("updated_at")
+  userId          Int           @id @default(autoincrement()) @map("user_id")
+  email           String        @unique @map("email")
+  password        String        @map("password")
+  username        String        @map("username")
+  profileImage    String?       @map("profile_image")
+  introduction    String?       @map("introduction")
+  createdAt       DateTime      @default(now()) @map("created_at")
+  updatedAt       DateTime      @updatedAt @map("updated_at")
 
-  post          Post[]
-  comment       Comment[]
-  postLike      PostLike[]
-  commentLike   CommentLike[]
-  refreshToken  RefreshToken?
+  post            Post[]
+  comment         Comment[]
+  postLike        PostLike[]
+  commentLike     CommentLike[]
+  refreshToken    RefreshToken?
 
   @@map("users")
 }
@@ -58,35 +58,35 @@ model Comment {
 }
 
 model PostLike {
-  id            BigInt        @id @default(autoincrement()) @map("id")
-  userId        Int           @map("user_id")
-  postId        Int           @map("post_id")
+  post_like_id      BigInt        @id @default(autoincrement()) @map("id")
+  userId            Int           @map("user_id")
+  postId            Int           @map("post_id")
 
-  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  post          Post          @relation(fields: [postId], references: [postId], onDelete: Cascade)
+  user              User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  post              Post          @relation(fields: [postId], references: [postId], onDelete: Cascade)
 
   @@map("post_likes")
 }
 
 model CommentLike {
-  id            BigInt        @id @default(autoincrement()) @map("id")
-  userId        Int           @map("user_id")
-  commentId     Int           @map("comment_id")
+  comment_like_id   BigInt        @id @default(autoincrement()) @map("id")
+  userId            Int           @map("user_id")
+  commentId         Int           @map("comment_id")
 
-  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
-  comment       Comment       @relation(fields: [commentId], references: [commentId], onDelete: Cascade)
+  user              User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  comment           Comment       @relation(fields: [commentId], references: [commentId], onDelete: Cascade)
 
   @@map("comment_likes")
 }
 
 model RefreshToken {
-  tokenId       Int           @id @default(autoincrement()) @map("token_id")
-  userId        Int           @unique @map("user_id")
-  refreshToken  String        @map("refresh_token")
-  createdAt     DateTime      @default(now()) @map("created_at")
-  updatedAt     DateTime      @updatedAt @map("updated_at")
+  tokenId           Int           @id @default(autoincrement()) @map("token_id")
+  userId            Int           @unique @map("user_id")
+  refreshToken      String        @map("refresh_token")
+  createdAt         DateTime      @default(now()) @map("created_at")
+  updatedAt         DateTime      @updatedAt @map("updated_at")
 
-  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  user              User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
 
   @@map("refresh_tokens")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model Post {
   title         String        @map("title")
   content       String        @db.Text @map("content")
   imageUrl      String?       @map("image_url")
-  like_count    Int           @default(0) @map("like_count")
+  likeCount    Int           @default(0) @map("like_count")
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 
@@ -48,7 +48,7 @@ model Comment {
   commenterId   Int           @map("commenter_id")
   postId        Int           @map("post_id")
   content       String        @map("content")
-  like_count    Int           @default(0) @map("like_count")
+  likeCount    Int           @default(0) @map("like_count")
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model User {
 
 model Post {
   postId        Int           @id @default(autoincrement()) @map("post_id")
-  userId        Int           @map("user_id")
+  authorId      Int           @map("author_id")
   title         String        @map("title")
   content       String        @db.Text @map("content")
   imageUrl      String?       @map("image_url")
@@ -36,7 +36,7 @@ model Post {
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 
-  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  user          User          @relation(fields: [authorId], references: [userId], onDelete: Cascade)
   comment       Comment[]
   postLike      PostLike[]
 
@@ -45,14 +45,14 @@ model Post {
 
 model Comment {
   commentId     Int           @id @default(autoincrement()) @map("comment_id")
-  userId        Int           @map("user_id")
+  commenterId   Int           @map("commenter_id")
   postId        Int           @map("post_id")
   content       String        @map("content")
   like_count    Int           @default(0) @map("like_count")
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 
-  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  user          User          @relation(fields: [commenterId], references: [userId], onDelete: Cascade)
   post          Post          @relation(fields: [postId], references: [postId], onDelete: Cascade)
   commentLike   CommentLike[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,8 @@ model User {
 
   post          Post[]
   comment       Comment[]
-  like          Like[]
+  postLike      PostLike[]
+  commentLike   CommentLike[]
   refreshToken  RefreshToken?
 
   @@map("users")
@@ -36,7 +37,7 @@ model Post {
 
   user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
   comment       Comment[]
-  like          Like[]
+  postLike      PostLike[]
 
   @@map("posts")
 }
@@ -51,23 +52,31 @@ model Comment {
 
   user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
   post          Post          @relation(fields: [postId], references: [postId], onDelete: Cascade)
-  like          Like[]
+  commentLike   CommentLike[]
 
   @@map("comments")
 }
 
-model Like {
-  likeId        BigInt        @id @default(autoincrement()) @map("like_id")
+model PostLike {
+  id            BigInt        @id @default(autoincrement()) @map("id")
   userId        Int           @map("user_id")
   postId        Int           @map("post_id")
-  commentId     Int?          @map("comment_id")
-  createdAt     DateTime      @default(now()) @map("created_at")
 
   user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
   post          Post          @relation(fields: [postId], references: [postId], onDelete: Cascade)
-  comment       Comment?      @relation(fields: [commentId], references: [commentId], onDelete: Cascade)
 
-  @@map("likes")
+  @@map("post_likes")
+}
+
+model CommentLike {
+  id            BigInt        @id @default(autoincrement()) @map("id")
+  userId        Int           @map("user_id")
+  commentId     Int           @map("comment_id")
+
+  user          User          @relation(fields: [userId], references: [userId], onDelete: Cascade)
+  comment       Comment       @relation(fields: [commentId], references: [commentId], onDelete: Cascade)
+
+  @@map("comment_likes")
 }
 
 model RefreshToken {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Post {
   title         String        @map("title")
   content       String        @db.Text @map("content")
   imageUrl      String?       @map("image_url")
+  like_count    Int           @default(0) @map("like_count")
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 
@@ -47,6 +48,7 @@ model Comment {
   userId        Int           @map("user_id")
   postId        Int           @map("post_id")
   content       String        @map("content")
+  like_count    Int           @default(0) @map("like_count")
   createdAt     DateTime      @default(now()) @map("created_at")
   updatedAt     DateTime      @updatedAt @map("updated_at")
 

--- a/src/constants/http-status.constant.js
+++ b/src/constants/http-status.constant.js
@@ -2,9 +2,9 @@ export const HTTP_STATUS = {
   OK: 200, // 호출 성공
   CREATED: 201, // 생성 성공
   BAD_REQUEST: 400, // 클라이언트가 잘못 요청 (예: 입력값 빠뜨림)
-  NOT_FOUND: 404, // 클라이언트가 요청한 정보를 찾을 수 없음
   UNAUTHORIZED: 401, // 인증 실패 unauthenticated (예: 비밀번호 틀림)
   FORBIDDEN: 403, // 인가 실패 unauthorized (예: 접근권한이 없음)
+  NOT_FOUND: 404, // 클라이언트가 요청한 정보를 찾을 수 없음
   CONFLICT: 409, // 충돌 발생 (예: 이메일 중복)
   INTERNAL_SERVER_ERROR: 500, // 예상치 못한 에러 발생
 };

--- a/src/constants/http-status.constant.js
+++ b/src/constants/http-status.constant.js
@@ -1,8 +1,8 @@
 export const HTTP_STATUS = {
   OK: 200, // 호출 성공
   CREATED: 201, // 생성 성공
-  BAD_REQUEST: 400, // 사용자가 잘못 요청 (예: 입력값 빠뜨림)
-  NOT_FOUND: 404,
+  BAD_REQUEST: 400, // 클라이언트가 잘못 요청 (예: 입력값 빠뜨림)
+  NOT_FOUND: 404, // 클라이언트가 요청한 정보를 찾을 수 없음
   UNAUTHORIZED: 401, // 인증 실패 unauthenticated (예: 비밀번호 틀림)
   FORBIDDEN: 403, // 인가 실패 unauthorized (예: 접근권한이 없음)
   CONFLICT: 409, // 충돌 발생 (예: 이메일 중복)

--- a/src/middlewares/error-handler.middleware.js
+++ b/src/middlewares/error-handler.middleware.js
@@ -5,12 +5,12 @@ const errorHandler = (err, req, res, next) => {
     // JWT verify method에서 발생한 에러 처리
     case 'TokenExpiredError':
       return res
-        .status(HTTP_STATUS.BAD_REQUEST)
-        .json({ status: HTTP_STATUS.BAD_REQUEST, message: '인증 정보가 만료되었습니다.' });
+        .status(HTTP_STATUS.UNAUTHORIZED)
+        .json({ status: HTTP_STATUS.UNAUTHORIZED, message: '인증 정보가 만료되었습니다.' });
     case 'JsonWebTokenError':
       return res
-        .status(HTTP_STATUS.BAD_REQUEST)
-        .json({ status: HTTP_STATUS.BAD_REQUEST, message: '인증 정보가 유효하지 않습니다.' });
+        .status(HTTP_STATUS.UNAUTHORIZED)
+        .json({ status: HTTP_STATUS.UNAUTHORIZED, message: '인증 정보가 유효하지 않습니다.' });
 
     // CustomError로 받은 에러 처리
     case 'CustomError':

--- a/src/routers/comments.router.js
+++ b/src/routers/comments.router.js
@@ -24,8 +24,8 @@ commentRouter.post('/:postId/comments', commentValidator, async (req, res, next)
 
     const comment = await prisma.comment.create({
       data: {
+        commenterId: userId,
         postId: +postId,
-        userId,
         content,
       },
     });
@@ -64,6 +64,7 @@ commentRouter.get('/:postId/comments', async (req, res, next) => {
         username: comment.user.username,
         profileImage: comment.user.profileImage,
         content: comment.content,
+        likeCount: comment.likeCount,
         createdAt: comment.createdAt,
         updatedAt: comment.updatedAt,
       };
@@ -84,7 +85,9 @@ commentRouter.patch('/:postId/comments/:commentId', commentValidator, async (req
     const { commentId } = req.params;
     const { content } = req.body;
 
-    const comment = await prisma.comment.findFirst({ where: { userId, commentId: +commentId } });
+    const comment = await prisma.comment.findFirst({
+      where: { commenterId: userId, commentId: +commentId },
+    });
 
     if (!comment) {
       return res
@@ -93,7 +96,7 @@ commentRouter.patch('/:postId/comments/:commentId', commentValidator, async (req
     }
 
     const updatedComment = await prisma.comment.update({
-      where: { userId, commentId: +commentId },
+      where: { commenterId: userId, commentId: +commentId },
       data: { content },
     });
 
@@ -113,7 +116,9 @@ commentRouter.delete('/:postId/comments/:commentId', async (req, res, next) => {
     const userId = 1;
     const { commentId } = req.params;
 
-    const comment = await prisma.comment.findUnique({ where: { userId, commentId: +commentId } });
+    const comment = await prisma.comment.findUnique({
+      where: { commenterId: userId, commentId: +commentId },
+    });
 
     if (!comment) {
       return res
@@ -121,7 +126,9 @@ commentRouter.delete('/:postId/comments/:commentId', async (req, res, next) => {
         .json({ status: HTTP_STATUS.NOT_FOUND, message: '존재하지 않는 댓글입니다.' });
     }
 
-    await prisma.comment.delete({ where: { userId, commentId: +commentId } });
+    await prisma.comment.delete({
+      where: { commenterId: userId, commentId: +commentId },
+    });
 
     return res.status(HTTP_STATUS.OK).json({ status: HTTP_STATUS.OK, message: `${commentId}번 댓글을 삭제했습니다.` });
   } catch (error) {

--- a/src/routers/likes.router.js
+++ b/src/routers/likes.router.js
@@ -4,7 +4,7 @@ import { HTTP_STATUS } from '../constants/http-status.constant.js';
 
 const likeRouter = express.Router();
 
-// 특정 게시글에 좋아요 클릭 및 취소 API <<< TODO: AccessToken 인증 미들웨어 거쳐야함
+// 게시글에 좋아요/취소 API <<< TODO: AccessToken 인증 미들웨어 거쳐야함
 likeRouter.put('/:postId/likes', async (req, res, next) => {
   try {
     const { userId } = req.user;
@@ -62,7 +62,7 @@ likeRouter.put('/:postId/likes', async (req, res, next) => {
   }
 });
 
-// 특정 게시글의 좋아요 조회 API
+// 게시글의 좋아요 조회 API
 likeRouter.get('/:postId/likes', async (req, res, next) => {
   try {
     const { postId } = req.params;
@@ -87,7 +87,7 @@ likeRouter.get('/:postId/likes', async (req, res, next) => {
   }
 });
 
-// 특정 댓글에 좋아요 클릭 및 취소 API <<< TODO: AccessToken 인증 미들웨어 거쳐야함
+// 댓글에 좋아요/취소 API <<< TODO: AccessToken 인증 미들웨어 거쳐야함
 likeRouter.put('/:postId/comments/:commentId/likes', async (req, res, next) => {
   try {
     const { userId } = req.user;
@@ -145,7 +145,7 @@ likeRouter.put('/:postId/comments/:commentId/likes', async (req, res, next) => {
   }
 });
 
-// 특정 댓글의 좋아요 조회 API
+// 댓글의 좋아요 조회 API
 likeRouter.get('/:postId/comments/:commentId/likes', async (req, res, next) => {
   try {
     const { commentId } = req.params;

--- a/src/routers/likes.router.js
+++ b/src/routers/likes.router.js
@@ -7,18 +7,20 @@ const likeRouter = express.Router();
 // 게시글에 좋아요/취소 API <<< TODO: AccessToken 인증 미들웨어 거쳐야함
 likeRouter.put('/:postId/likes', async (req, res, next) => {
   try {
-    const { userId } = req.user;
+    const userId = 1; //테스트용
+    // const { userId } = req.user;
     const { postId } = req.params;
 
-    // 해당 게시글의 작성자 id 가져오기
-    const { userId: authorId } = await prisma.post.findUnique({
-      where: {
-        postId: +postId,
-      },
+    // 해당 게시글 가져오기
+    const post = await prisma.post.findUnique({
+      where: { postId: +postId },
     });
 
+    // 해당 게시글이 존재하는지 확인
+    if (!post) throw new Error('해당 게시글이 존재하지 않습니다.');
+
     // 본인이 작성한 게시글인지 확인
-    if (userId === authorId) {
+    if (userId === post.authorId) {
       throw new Error('본인이 작성한 게시글에는 좋아요를 누를 수 없습니다.');
     }
 
@@ -67,11 +69,17 @@ likeRouter.get('/:postId/likes', async (req, res, next) => {
   try {
     const { postId } = req.params;
 
+    // 해당 게시글 가져오기
+    const post = await prisma.post.findUnique({
+      where: { postId: +postId },
+    });
+
+    // 해당 게시글이 존재하는지 확인
+    if (!post) throw new Error('해당 게시글이 존재하지 않습니다.');
+
     // likes 테이블에서 특정 posts의 좋아요 검색
     const likes = await prisma.postLike.findMany({
-      where: {
-        postId: +postId,
-      },
+      where: { postId: +postId },
     });
 
     // 반환 정보
@@ -93,15 +101,16 @@ likeRouter.put('/:postId/comments/:commentId/likes', async (req, res, next) => {
     const { userId } = req.user;
     const { commentId } = req.params;
 
-    // 해당 댓글의 작성자 id 가져오기
-    const { userId: commenterId } = await prisma.comment.findUnique({
-      where: {
-        commentId: +commentId,
-      },
+    // 해당 댓글 가져오기
+    const comment = await prisma.comment.findUnique({
+      where: { commentId: +commentId },
     });
 
+    // 해당 게시글이 존재하는지 확인
+    if (!comment) throw new Error('해당 댓글이 존재하지 않습니다.');
+
     // 본인이 작성한 댓글인지 확인
-    if (userId === commenterId) {
+    if (userId === comment.commenterId) {
       throw new Error('본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.');
     }
 
@@ -150,11 +159,17 @@ likeRouter.get('/:postId/comments/:commentId/likes', async (req, res, next) => {
   try {
     const { commentId } = req.params;
 
+    // 해당 댓글 가져오기
+    const comment = await prisma.comment.findUnique({
+      where: { commentId: +commentId },
+    });
+
+    // 해당 게시글이 존재하는지 확인
+    if (!comment) throw new Error('해당 댓글이 존재하지 않습니다.');
+
     // likes 테이블에서 해당 댓글의 좋아요 검색
     const likes = await prisma.commentLike.findMany({
-      where: {
-        commentId: +commentId,
-      },
+      where: { commentId: +commentId },
     });
 
     // 반환 정보


### PR DESCRIPTION
- Comment: 404 주석 추가
- Rename: JWT verify 에러코드 400->401로 수정
- Refactor: likes 테이블을 post_likes와 comment_likes로 분리
- Rename: post_likes 테이블과 comment_likes 테이블의 primary key 이름을 수정
- Refactor: likes 테이블의 분리에 따른 likes.router.js코드 수정
- Add: posts 테이블과 comments 테이블에 like_count 추가
- Rename: posts 테이블과 comments 테이블의 user_id를 각각 author_id, commenter_id 수정
- Rename: comments 테이블의 user_id -> commenter_id 이름 변경에 따라 comments.router.js도 수정
- Update: likes.router.js에서 해당 게시글 및 댓글 존재하는지 확인하는 과정 추가