### PR TITLE
Refactor: 좋아요 클릭/취소 시 transaction 처리 #9

### DIFF
--- a/src/routers/likes.router.js
+++ b/src/routers/likes.router.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from '../utils/prisma.util.js';
+import { Prisma } from '@prisma/client';
 import { HTTP_STATUS } from '../constants/http-status.constant.js';
 
 const likeRouter = express.Router();
@@ -17,14 +18,22 @@ likeRouter.put('/:postId/likes', async (req, res, next) => {
     });
 
     // 해당 게시글이 존재하는지 확인
-    if (!post) throw new Error('해당 게시글이 존재하지 않습니다.');
+    if (!post) {
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        message: '해당 게시글이 존재하지 않습니다.',
+      });
+    }
 
     // 본인이 작성한 게시글인지 확인
     if (userId === post.authorId) {
-      throw new Error('본인이 작성한 게시글에는 좋아요를 누를 수 없습니다.');
+      return res.status(HTTP_STATUS.FORBIDDEN).json({
+        status: HTTP_STATUS.FORBIDDEN,
+        message: '본인이 작성한 게시글에는 좋아요를 누를 수 없습니다.',
+      });
     }
 
-    // likes 테이블에서 해당 유저가 해당 게시글에 남긴 좋아요를 검색
+    // post_likes 테이블에서 해당 유저가 해당 게시글에 남긴 좋아요를 검색
     const like = await prisma.postLike.findUnique({
       where: {
         userId: userId,
@@ -32,24 +41,52 @@ likeRouter.put('/:postId/likes', async (req, res, next) => {
       },
     });
 
-    // 없으면 좋아요 생성
+    // 없으면
     if (!like) {
-      await prisma.postLike.create({
-        data: {
-          userId: userId,
-          postId: +postId,
+      await prisma.$transaction(
+        async (txn) => {
+          // post_likes 테이블에 데이터 생성
+          await txn.postLike.create({
+            data: {
+              userId: userId,
+              postId: +postId,
+            },
+          });
+          // posts 테이블의 해당 post의 like_count를 +1
+          await txn.post.update({
+            where: { postId: +postId },
+            data: { likeCount: post.likeCount + 1 },
+          });
         },
-      });
+        {
+          //격리 수준 설정
+          isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+        },
+      );
     }
 
-    // 있으면 좋아요 삭제
+    // 있으면
     else {
-      await prisma.postLike.delete({
-        where: {
-          userId: userId,
-          postId: +postId,
+      await prisma.$transaction(
+        async (txn) => {
+          // post_likes 테이블에서 데이터 삭제
+          await txn.postLike.delete({
+            data: {
+              userId: userId,
+              postId: +postId,
+            },
+          });
+          // posts 테이블의 해당 post의 like_count를 -1
+          await txn.post.update({
+            where: { postId: +postId },
+            data: { likeCount: post.likeCount - 1 },
+          });
         },
-      });
+        {
+          //격리 수준 설정
+          isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+        },
+      );
     }
 
     // 반환 정보
@@ -75,7 +112,12 @@ likeRouter.get('/:postId/likes', async (req, res, next) => {
     });
 
     // 해당 게시글이 존재하는지 확인
-    if (!post) throw new Error('해당 게시글이 존재하지 않습니다.');
+    if (!post) {
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        message: '해당 게시글이 존재하지 않습니다.',
+      });
+    }
 
     // likes 테이블에서 특정 posts의 좋아요 검색
     const likes = await prisma.postLike.findMany({
@@ -106,15 +148,23 @@ likeRouter.put('/:postId/comments/:commentId/likes', async (req, res, next) => {
       where: { commentId: +commentId },
     });
 
-    // 해당 게시글이 존재하는지 확인
-    if (!comment) throw new Error('해당 댓글이 존재하지 않습니다.');
+    // 해당 댓글이 존재하는지 확인
+    if (!comment) {
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        message: '해당 댓글이 존재하지 않습니다.',
+      });
+    }
 
     // 본인이 작성한 댓글인지 확인
     if (userId === comment.commenterId) {
-      throw new Error('본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.');
+      return res.status(HTTP_STATUS.FORBIDDEN).json({
+        status: HTTP_STATUS.FORBIDDEN,
+        message: '본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.',
+      });
     }
 
-    // likes 테이블에서 해당 유저가 해당 댓글에 남긴 좋아요를 검색
+    // comment_likes 테이블에서 해당 유저가 해당 댓글에 남긴 좋아요를 검색
     const like = await prisma.commentLike.findUnique({
       where: {
         userId: userId,
@@ -122,24 +172,52 @@ likeRouter.put('/:postId/comments/:commentId/likes', async (req, res, next) => {
       },
     });
 
-    // 없으면 좋아요 생성
+    // 없으면 좋아요
     if (!like) {
-      await prisma.commentLike.create({
-        data: {
-          userId: userId,
-          commentId: +commentId,
+      await prisma.$transaction(
+        async (txn) => {
+          // comment_likes 테이블에 데이터 생성
+          await txn.commentLike.create({
+            data: {
+              userId: userId,
+              commentId: +commentId,
+            },
+          });
+          // comments 테이블의 해당 comment의 like_count를 +1
+          await txn.post.update({
+            where: { commentId: +commentId },
+            data: { likeCount: comment.likeCount + 1 },
+          });
         },
-      });
+        {
+          //격리 수준 설정
+          isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+        },
+      );
     }
 
-    // 있으면 좋아요 삭제
+    // 있으면 좋아요 취소
     if (like) {
-      await prisma.commentLike.delete({
-        where: {
-          userId: userId,
-          commentId: +commentId,
+      await prisma.$transaction(
+        async (txn) => {
+          // comment_likes 테이블에서 데이터 삭제
+          await txn.commentLike.delete({
+            data: {
+              userId: userId,
+              commentId: +commentId,
+            },
+          });
+          // comments 테이블의 해당 comment의 like_count를 -1
+          await txn.post.update({
+            where: { commentId: +commentId },
+            data: { likeCount: comment.likeCount - 1 },
+          });
         },
-      });
+        {
+          //격리 수준 설정
+          isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+        },
+      );
     }
 
     // 반환 정보
@@ -164,8 +242,13 @@ likeRouter.get('/:postId/comments/:commentId/likes', async (req, res, next) => {
       where: { commentId: +commentId },
     });
 
-    // 해당 게시글이 존재하는지 확인
-    if (!comment) throw new Error('해당 댓글이 존재하지 않습니다.');
+    // 해당 댓글이 존재하는지 확인
+    if (!comment) {
+      return res.status(HTTP_STATUS.NOT_FOUND).json({
+        status: HTTP_STATUS.NOT_FOUND,
+        message: '해당 댓글이 존재하지 않습니다.',
+      });
+    }
 
     // likes 테이블에서 해당 댓글의 좋아요 검색
     const likes = await prisma.commentLike.findMany({


### PR DESCRIPTION
- 게시글 좋아요 클릭/취소 시 'post_likes에 데이터 생성/삭제' 와 'posts 테이블에서 해당 post의 like_count를 +1/-1 업데이트 하는 것을 transaction으로 묶어서 처리'
- 댓글 좋아요 클릭/취소 시 'comment_likes에 데이터 생성/삭제' 와 'comments 테이블에서 해당 comment의 like_count를 +1/-1 업데이트 하는 것을 transaction으로 묶어서 처리'

related to #7 #8